### PR TITLE
feat: generic COM interface support with type-safe vtables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ version = "0.1.0"
 dependencies = [
  "cppvtable-macro",
  "paste",
+ "windows-core",
 ]
 
 [[package]]
@@ -211,3 +212,62 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]

--- a/crates/cppvtable-macro/src/lib.rs
+++ b/crates/cppvtable-macro/src/lib.rs
@@ -784,14 +784,15 @@ fn cppvtable_internal(config: VTableConfig, input: ItemTrait) -> Result<TokenStr
             let d4_5 = data4[5];
             let d4_6 = data4[6];
             let d4_7 = data4[7];
+            // Use make_guid helper function for windows-compat compatibility
             let def = quote! {
                 /// COM Interface ID (GUID) for this interface
-                #vis const #iid_static_name: #krate::GUID = #krate::GUID {
-                    data1: #data1,
-                    data2: #data2,
-                    data3: #data3,
-                    data4: [#d4_0, #d4_1, #d4_2, #d4_3, #d4_4, #d4_5, #d4_6, #d4_7],
-                };
+                #vis const #iid_static_name: #krate::GUID = #krate::make_guid(
+                    #data1,
+                    #data2,
+                    #data3,
+                    [#d4_0, #d4_1, #d4_2, #d4_3, #d4_4, #d4_5, #d4_6, #d4_7],
+                );
             };
             let methods = quote! {
                 /// Get the interface ID (GUID) for this COM interface

--- a/crates/cppvtable-macro/src/lib.rs
+++ b/crates/cppvtable-macro/src/lib.rs
@@ -3,9 +3,17 @@
 //! Provides:
 //! - `#[cppvtable]` - Define a C++ interface (generates vtable struct)
 //! - `#[cppvtable_impl(Interface)]` - Implement an interface for a struct
+//! - `#[com_interface("guid")]` - Define a COM interface with IUnknown base
+//! - `#[com_implement(Interface)]` - Implement a COM interface for a struct
 //!
-//! Automatically selects calling convention based on target:
+//! ## Calling Conventions
+//!
+//! **C++ vtables (`cppvtable`):**
 //! - x86: `thiscall` (this in ECX)
+//! - x64: `C` (this as first param)
+//!
+//! **COM interfaces (`com_interface`):**
+//! - x86: `stdcall` (this on stack)
 //! - x64: `C` (this as first param)
 //!
 //! Supports explicit slot indices via `#[slot(N)]` attribute on methods.
@@ -23,6 +31,171 @@ use syn::{
     Attribute, Expr, FnArg, Ident, ImplItem, ItemImpl, ItemTrait, Lit, Meta, Pat, TraitItem, Type,
     parse_macro_input, spanned::Spanned,
 };
+
+/// Returns the path to the cppvtable crate.
+///
+/// Returns the path to the cppvtable crate based on the `internal` flag.
+///
+/// When `internal` is true (used inside the cppvtable crate itself), this returns `crate::`.
+/// When `internal` is false (external crates), this returns `cppvtable::`.
+fn crate_path(internal: bool) -> TokenStream2 {
+    if internal {
+        quote! { crate }
+    } else {
+        quote! { cppvtable }
+    }
+}
+
+/// Transforms a type to use `$crate::` prefix for cppvtable types.
+///
+/// This is used when generating declarative macros that will be invoked from user code.
+/// In that context, `$crate` resolves to the crate where the macro is defined (cppvtable).
+///
+/// Types transformed:
+/// - `GUID` -> `$crate::GUID`
+/// - `HRESULT` -> `$crate::HRESULT`
+/// - `c_void` -> `::std::ffi::c_void`
+fn qualify_type_for_macro(ty: &Type) -> TokenStream2 {
+    match ty {
+        Type::Path(type_path) => {
+            // Check if it's a simple identifier we need to qualify
+            if let Some(ident) = type_path.path.get_ident() {
+                let name = ident.to_string();
+                match name.as_str() {
+                    "GUID" | "HRESULT" => {
+                        // These are cppvtable types, need $crate:: prefix
+                        return quote! { $crate::#ident };
+                    }
+                    "c_void" => {
+                        // Use fully qualified std path
+                        return quote! { ::std::ffi::c_void };
+                    }
+                    _ => {}
+                }
+            }
+            // Keep other paths as-is
+            quote! { #ty }
+        }
+        Type::Ptr(type_ptr) => {
+            let inner = qualify_type_for_macro(&type_ptr.elem);
+            if type_ptr.const_token.is_some() {
+                if type_ptr.mutability.is_some() {
+                    quote! { *const mut #inner }
+                } else {
+                    quote! { *const #inner }
+                }
+            } else if type_ptr.mutability.is_some() {
+                quote! { *mut #inner }
+            } else {
+                quote! { *#inner }
+            }
+        }
+        Type::Reference(type_ref) => {
+            let inner = qualify_type_for_macro(&type_ref.elem);
+            let lifetime = &type_ref.lifetime;
+            if type_ref.mutability.is_some() {
+                quote! { &#lifetime mut #inner }
+            } else {
+                quote! { &#lifetime #inner }
+            }
+        }
+        // For other types, keep as-is
+        _ => quote! { #ty },
+    }
+}
+
+// =============================================================================
+// Configuration types for vtable generation
+// =============================================================================
+
+/// Calling convention for vtable methods
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+enum CallingConvention {
+    /// C++ thiscall: this in ECX on x86, first param on x64
+    #[default]
+    Thiscall,
+    /// COM stdcall: this on stack on x86, first param on x64
+    Stdcall,
+}
+
+/// Interface ID type
+#[derive(Clone, Default)]
+enum InterfaceId {
+    /// Pointer-based ID (address of a static)
+    #[default]
+    Pointer,
+    /// GUID-based ID (COM style)
+    Guid {
+        data1: u32,
+        data2: u16,
+        data3: u16,
+        data4: [u8; 8],
+    },
+    /// No IID generation (for interfaces that define their own IID)
+    None,
+}
+
+/// Configuration for vtable generation
+#[derive(Clone, Default)]
+struct VTableConfig {
+    /// Calling convention (thiscall vs stdcall)
+    calling_convention: CallingConvention,
+    /// Base interface to inherit from (e.g., IUnknown)
+    /// When set, the generated vtable embeds the base vtable as the first field
+    base_interface: Option<syn::Ident>,
+    /// Interface ID type
+    iid: InterfaceId,
+    /// Slot overrides from attribute
+    slot_overrides: std::collections::HashMap<String, usize>,
+    /// Internal mode: use `crate::` instead of `cppvtable::` for paths
+    /// This is used when defining interfaces inside the cppvtable crate itself
+    internal: bool,
+    /// Skip generating forwarder macros ({interface}_forwarders! and {interface}_base_vtable!)
+    /// Use this when the forwarders need to be manually defined (e.g., IUnknown with COM types)
+    no_forwarders: bool,
+}
+
+impl VTableConfig {
+    /// Generate the x86 calling convention token
+    fn x86_calling_conv(&self) -> TokenStream2 {
+        match self.calling_convention {
+            CallingConvention::Thiscall => quote! { "thiscall" },
+            CallingConvention::Stdcall => quote! { "stdcall" },
+        }
+    }
+}
+
+/// Configuration for vtable implementation generation
+#[derive(Clone, Default)]
+struct ImplConfig {
+    /// Calling convention (thiscall vs stdcall)
+    calling_convention: CallingConvention,
+    /// Base interface to inherit from (e.g., IUnknown)
+    /// When set, generates forwarders and base vtable entry via the base's macros:
+    /// - `{base}_forwarders!` - generates wrapper functions
+    /// - `{base}_base_vtable!` - generates base vtable initializer
+    /// - `{base}_methods!` - generates method implementations on the struct
+    base_interface: Option<syn::Ident>,
+    /// First slot index for user methods (e.g., 3 for IUnknown base)
+    /// Caller must set this based on the base interface's slot count
+    first_slot: usize,
+    /// Whether to generate RTTI info
+    generate_rtti: bool,
+    /// IID constant name for COM (e.g., IID_ICALCULATOR)
+    iid_const: Option<syn::Ident>,
+    /// Internal mode: use `crate::` instead of `cppvtable::` for paths
+    internal: bool,
+}
+
+impl ImplConfig {
+    /// Generate the x86 calling convention token
+    fn x86_calling_conv(&self) -> TokenStream2 {
+        match self.calling_convention {
+            CallingConvention::Thiscall => quote! { "thiscall" },
+            CallingConvention::Stdcall => quote! { "stdcall" },
+        }
+    }
+}
 
 // =============================================================================
 // Validation helpers for FFI-safety and C++ compatibility
@@ -362,30 +535,6 @@ fn parse_slot_attr(attrs: &[Attribute]) -> Option<usize> {
     None
 }
 
-/// Parse slot overrides from attribute: slots(method_name = N, ...)
-/// Returns a map of method name -> slot index
-fn parse_slot_overrides(attr: TokenStream) -> std::collections::HashMap<String, usize> {
-    let mut overrides = std::collections::HashMap::new();
-    let attr_str = attr.to_string();
-
-    // Parse "slots(method1 = 3, method2 = 5, ...)"
-    if let Some(inner) = attr_str.strip_prefix("slots").map(|s| s.trim())
-        && let Some(inner) = inner.strip_prefix('(').and_then(|s| s.strip_suffix(')'))
-    {
-        for assignment in inner.split(',') {
-            let parts: Vec<&str> = assignment.split('=').collect();
-            if parts.len() == 2 {
-                let method = parts[0].trim();
-                if let Ok(slot) = parts[1].trim().parse::<usize>() {
-                    overrides.insert(method.to_string(), slot);
-                }
-            }
-        }
-    }
-
-    overrides
-}
-
 /// Convert interface name to vtable field name (snake_case with vtable_ prefix)
 /// IFoo -> vtable_i_foo
 /// IAnimal -> vtable_i_animal
@@ -417,17 +566,32 @@ fn interface_to_field_name(interface: &Ident) -> Ident {
     format_ident!("{}", result)
 }
 
-/// Internal implementation of cppvtable
-fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream2, syn::Error> {
+/// Internal implementation of cppvtable - unified for both C++ and COM interfaces
+fn cppvtable_internal(config: VTableConfig, input: ItemTrait) -> Result<TokenStream2, syn::Error> {
     // Validate trait for C++ vtable compatibility
     validate_trait(&input)?;
 
     let trait_name = &input.ident;
     let vtable_name = format_ident!("{}VTable", trait_name);
     let vis = &input.vis;
+    let x86_cc = config.x86_calling_conv();
 
-    // Parse slot mappings from attribute: slots(method_name = N, ...)
-    let slot_overrides = parse_slot_overrides(attr);
+    // Handle base interface inheritance
+    // When a base is specified:
+    // - Embed the base vtable struct as the first field
+    // - Own method slots start at 0 (relative to derived portion)
+    // - Total slot count = base slot count + own method count
+    let krate = crate_path(config.internal);
+    let base_vtable_field = config.base_interface.as_ref().map(|base_ident| {
+        quote! {
+            /// Inherited base interface vtable
+            pub base: <#base_ident as #krate::VTableLayout>::VTable
+        }
+    });
+
+    // When extending, slot indices are relative to the derived interface
+    // (slot 0 = first method after base)
+    let first_slot = 0usize;
 
     // Collect methods with their slot indices
     struct MethodInfo {
@@ -439,7 +603,7 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
     }
 
     let mut methods: Vec<MethodInfo> = Vec::new();
-    let mut next_slot = 0usize;
+    let mut next_slot = first_slot;
 
     for item in &input.items {
         if let TraitItem::Fn(method) = item {
@@ -447,7 +611,18 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
             let output = method.sig.output.clone();
 
             // Check for slot override from attribute, then #[slot(N)] on method
-            let slot = if let Some(&explicit_slot) = slot_overrides.get(&method_name.to_string()) {
+            let slot = if let Some(&explicit_slot) =
+                config.slot_overrides.get(&method_name.to_string())
+            {
+                if explicit_slot < first_slot {
+                    return Err(syn::Error::new(
+                        method_name.span(),
+                        format!(
+                            "slot({}) for method '{}' conflicts with base interface methods (first available: {})",
+                            explicit_slot, method_name, first_slot
+                        ),
+                    ));
+                }
                 if explicit_slot < next_slot {
                     return Err(syn::Error::new(
                         method_name.span(),
@@ -459,6 +634,15 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
                 }
                 explicit_slot
             } else if let Some(explicit_slot) = parse_slot_attr(&method.attrs) {
+                if explicit_slot < first_slot {
+                    return Err(syn::Error::new(
+                        method_name.span(),
+                        format!(
+                            "slot({}) for method '{}' conflicts with base interface methods (first available: {})",
+                            explicit_slot, method_name, first_slot
+                        ),
+                    ));
+                }
                 if explicit_slot < next_slot {
                     return Err(syn::Error::new(
                         method_name.span(),
@@ -515,7 +699,7 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
             let dummy_name = format_ident!("__reserved_slot_{}", current_slot);
             vtable_fields.push(quote! {
                 #[cfg(target_arch = "x86")]
-                pub #dummy_name: unsafe extern "thiscall" fn(this: *mut std::ffi::c_void),
+                pub #dummy_name: unsafe extern #x86_cc fn(this: *mut std::ffi::c_void),
                 #[cfg(not(target_arch = "x86"))]
                 pub #dummy_name: unsafe extern "C" fn(this: *mut std::ffi::c_void)
             });
@@ -527,11 +711,10 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
         let param_types = &method.param_types;
         let output = &method.output;
 
-        // Generate vtable field (function pointer)
-        // x86: thiscall (this in ECX), x64: C calling convention
+        // Generate vtable field (function pointer) using configured calling convention
         vtable_fields.push(quote! {
             #[cfg(target_arch = "x86")]
-            pub #method_name: unsafe extern "thiscall" fn(
+            pub #method_name: unsafe extern #x86_cc fn(
                 this: *mut std::ffi::c_void
                 #(, #param_names: #param_types)*
             ) #output,
@@ -543,7 +726,6 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
         });
 
         // Generate wrapper method on the base struct
-        // Note: The function is already `unsafe fn`, so no inner `unsafe` block needed
         wrapper_methods.push(quote! {
             #[inline]
             pub unsafe fn #method_name(&mut self #(, #param_names: #param_types)*) #output {
@@ -557,20 +739,327 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
         current_slot += 1;
     }
 
-    // Generate interface ID names
-    // IFoo -> IID_IFOO (static) and iid_i_foo() (helper function)
+    // Total slot count for VTableLayout
+    let total_slot_count = current_slot;
+
+    // Generate interface ID based on config
     let iid_static_name = format_ident!("IID_{}", trait_name.to_string().to_uppercase());
 
-    let expanded = quote! {
-        /// Unique interface ID for RTTI (address of this static serves as ID)
-        #[doc(hidden)]
-        #vis static #iid_static_name: u8 = 0;
+    // Generate IID definition and methods based on config
+    let (iid_definition, iid_methods) = match &config.iid {
+        InterfaceId::Pointer => {
+            let def = quote! {
+                /// Unique interface ID for RTTI (address of this static serves as ID)
+                #[doc(hidden)]
+                #vis static #iid_static_name: u8 = 0;
+            };
+            let methods = quote! {
+                /// Get the interface ID pointer for this interface type (const-compatible)
+                #[inline]
+                #[must_use]
+                pub const fn interface_id_ptr() -> *const u8 {
+                    &#iid_static_name as *const u8
+                }
 
-        /// VTable struct for #trait_name
-        #[repr(C)]
-        #vis struct #vtable_name {
-            #(#vtable_fields),*
+                /// Get the interface ID for this interface type as usize
+                #[inline]
+                #[must_use]
+                pub fn interface_id() -> usize {
+                    Self::interface_id_ptr() as usize
+                }
+            };
+            (def, methods)
         }
+        InterfaceId::Guid {
+            data1,
+            data2,
+            data3,
+            data4,
+        } => {
+            let d4_0 = data4[0];
+            let d4_1 = data4[1];
+            let d4_2 = data4[2];
+            let d4_3 = data4[3];
+            let d4_4 = data4[4];
+            let d4_5 = data4[5];
+            let d4_6 = data4[6];
+            let d4_7 = data4[7];
+            let def = quote! {
+                /// COM Interface ID (GUID) for this interface
+                #vis const #iid_static_name: #krate::GUID = #krate::GUID {
+                    data1: #data1,
+                    data2: #data2,
+                    data3: #data3,
+                    data4: [#d4_0, #d4_1, #d4_2, #d4_3, #d4_4, #d4_5, #d4_6, #d4_7],
+                };
+            };
+            let methods = quote! {
+                /// Get the interface ID (GUID) for this COM interface
+                #[inline]
+                #[must_use]
+                pub const fn iid() -> &'static #krate::GUID {
+                    &#iid_static_name
+                }
+            };
+            (def, methods)
+        }
+        InterfaceId::None => {
+            // No IID generation - user defines their own IID externally
+            (quote! {}, quote! {})
+        }
+    };
+
+    // Generate the slot count expression
+    // If we have a base, total = base slot count + own slot count
+    let own_slot_count = total_slot_count;
+    let slot_count_expr = if let Some(ref base_ident) = config.base_interface {
+        quote! { <#base_ident as #krate::VTableLayout>::SLOT_COUNT + #own_slot_count }
+    } else {
+        quote! { #own_slot_count }
+    };
+
+    // Generate vtable struct with optional base field
+    let vtable_struct = if let Some(ref base_field) = base_vtable_field {
+        quote! {
+            /// VTable struct for #trait_name
+            #[repr(C)]
+            #vis struct #vtable_name {
+                #base_field,
+                #(#vtable_fields),*
+            }
+        }
+    } else {
+        quote! {
+            /// VTable struct for #trait_name
+            #[repr(C)]
+            #vis struct #vtable_name {
+                #(#vtable_fields),*
+            }
+        }
+    };
+
+    // Generate IUnknown forwarding methods if extending IUnknown
+    let iunknown_wrappers = if config
+        .base_interface
+        .as_ref()
+        .is_some_and(|name| name == "IUnknown")
+    {
+        quote! {
+            /// Query for another interface by GUID (forwarded to base IUnknown)
+            ///
+            /// # Safety
+            /// - `riid` must point to a valid GUID
+            /// - `ppv` must point to a valid pointer location
+            #[inline]
+            pub unsafe fn query_interface(
+                &self,
+                riid: *const #krate::GUID,
+                ppv: *mut *mut std::ffi::c_void,
+            ) -> #krate::HRESULT {
+                unsafe {
+                    ((*self.vtable).base.query_interface)(
+                        self as *const Self as *mut std::ffi::c_void,
+                        riid,
+                        ppv,
+                    )
+                }
+            }
+
+            /// Increment reference count (forwarded to base IUnknown)
+            #[inline]
+            pub unsafe fn add_ref(&self) -> u32 {
+                unsafe {
+                    ((*self.vtable).base.add_ref)(self as *const Self as *mut std::ffi::c_void)
+                }
+            }
+
+            /// Decrement reference count (forwarded to base IUnknown)
+            #[inline]
+            pub unsafe fn release(&self) -> u32 {
+                unsafe {
+                    ((*self.vtable).base.release)(self as *const Self as *mut std::ffi::c_void)
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    // Generate {interface}_forwarders! and {interface}_base_vtable! macros
+    // These allow this interface to be used as a base for other interfaces
+    let interface_lower = trait_name.to_string().to_lowercase();
+    let forwarders_macro_name = format_ident!("{}_forwarders", interface_lower);
+    let base_vtable_macro_name = format_ident!("{}_base_vtable", interface_lower);
+
+    // Generate wrapper function code for each method in the forwarders macro
+    let mut forwarder_wrappers = Vec::new();
+    let mut vtable_entries = Vec::new();
+
+    for method in &methods {
+        let method_name = &method.name;
+        let method_name_str = method_name.to_string();
+        let param_names = &method.param_names;
+        let param_types = &method.param_types;
+        let output = &method.output;
+
+        // Qualify types for use in declarative macro context
+        // This transforms GUID -> $crate::GUID, HRESULT -> $crate::HRESULT, etc.
+        let qualified_param_types: Vec<_> =
+            param_types.iter().map(qualify_type_for_macro).collect();
+
+        // Build parameter list for function signature with qualified types
+        let params_with_types: Vec<_> = param_names
+            .iter()
+            .zip(qualified_param_types.iter())
+            .map(|(name, ty)| quote! { #name: #ty })
+            .collect();
+
+        // Qualify return type too
+        let qualified_output = match output {
+            syn::ReturnType::Default => quote! {},
+            syn::ReturnType::Type(arrow, ty) => {
+                let qualified_ty = qualify_type_for_macro(ty);
+                quote! { #arrow #qualified_ty }
+            }
+        };
+
+        // Build the method call arguments (just parameter names)
+        let call_args: Vec<_> = param_names.iter().map(|name| quote! { #name }).collect();
+
+        // Generate wrapper functions for x86 and x64
+        // Uses paste! for identifier concatenation with $struct_name and $interface_name
+        forwarder_wrappers.push(quote! {
+            #[allow(non_snake_case)]
+            #[cfg(target_arch = "x86")]
+            unsafe extern #x86_cc fn [<__ $struct_name __ $interface_name __ #method_name_str>](
+                this: *mut ::std::ffi::c_void
+                #(, #params_with_types)*
+            ) #qualified_output {
+                unsafe {
+                    let offset = ::std::mem::offset_of!($struct_type, $vtable_field);
+                    let adjusted = (this as *mut u8).sub(offset) as *mut $struct_type;
+                    (*adjusted).#method_name(#(#call_args),*)
+                }
+            }
+
+            #[allow(non_snake_case)]
+            #[cfg(not(target_arch = "x86"))]
+            unsafe extern "C" fn [<__ $struct_name __ $interface_name __ #method_name_str>](
+                this: *mut ::std::ffi::c_void
+                #(, #params_with_types)*
+            ) #qualified_output {
+                unsafe {
+                    let offset = ::std::mem::offset_of!($struct_type, $vtable_field);
+                    let adjusted = (this as *mut u8).sub(offset) as *mut $struct_type;
+                    (*adjusted).#method_name(#(#call_args),*)
+                }
+            }
+        });
+
+        // Generate vtable entry for base_vtable macro
+        vtable_entries.push(quote! {
+            #method_name: [<__ $struct_name __ $interface_name __ #method_name_str>]
+        });
+    }
+
+    // Generate the forwarders macro and base_vtable macro
+    // Skip if no_forwarders is set (e.g., for IUnknown where manual forwarders are needed)
+    let (forwarders_macro, base_vtable_macro) = if config.no_forwarders {
+        (quote! {}, quote! {})
+    } else if let Some(ref base_ident) = config.base_interface {
+        let base_lower = base_ident.to_string().to_lowercase();
+        let base_forwarders_macro = format_ident!("{}_forwarders", base_lower);
+        let parent_base_vtable_macro = format_ident!("{}_base_vtable", base_lower);
+        (
+            quote! {
+                /// Auto-generated forwarders macro for #trait_name.
+                ///
+                /// This macro generates wrapper functions that adjust the `this` pointer
+                /// and forward calls to the implementing struct's methods.
+                /// Also invokes the base interface's forwarders macro.
+                ///
+                /// # Parameters
+                /// - `$struct_name`: The implementing struct name (e.g., `Calculator`)
+                /// - `$struct_type`: The implementing struct type (e.g., `Calculator` or `Calculator<T>`)
+                /// - `$interface_name`: The interface being implemented (e.g., `ICalculator`)
+                /// - `$vtable_field`: The vtable pointer field name (e.g., `vtable_i_calculator`)
+                /// - `$iid_const`: The IID constant for the interface (unused but kept for consistency)
+                #[macro_export]
+                macro_rules! #forwarders_macro_name {
+                    ($struct_name:ident, $struct_type:ty, $interface_name:ident, $vtable_field:ident, $iid_const:ident) => {
+                        // First invoke base interface's forwarders
+                        $crate::#base_forwarders_macro!($struct_name, $struct_type, $interface_name, $vtable_field, $iid_const);
+
+                        // Then generate our own forwarders
+                        $crate::paste! {
+                            #(#forwarder_wrappers)*
+                        }
+                    };
+                }
+            },
+            quote! {
+                /// Auto-generated base vtable initializer macro for #trait_name.
+                ///
+                /// Returns an expression that creates `#vtable_name { base: ..., ... }` with the wrapper function pointers.
+                /// Recursively invokes the parent interface's base_vtable macro for the base field.
+                #[macro_export]
+                macro_rules! #base_vtable_macro_name {
+                    ($struct_name:ident, $interface_name:ident) => {
+                        $crate::paste! {
+                            #vtable_name {
+                                base: $crate::#parent_base_vtable_macro!($struct_name, $interface_name),
+                                #(#vtable_entries),*
+                            }
+                        }
+                    };
+                }
+            },
+        )
+    } else {
+        (
+            quote! {
+                /// Auto-generated forwarders macro for #trait_name.
+                ///
+                /// This macro generates wrapper functions that adjust the `this` pointer
+                /// and forward calls to the implementing struct's methods.
+                ///
+                /// # Parameters
+                /// - `$struct_name`: The implementing struct name (e.g., `Calculator`)
+                /// - `$struct_type`: The implementing struct type (e.g., `Calculator` or `Calculator<T>`)
+                /// - `$interface_name`: The interface being implemented (e.g., `ICalculator`)
+                /// - `$vtable_field`: The vtable pointer field name (e.g., `vtable_i_calculator`)
+                /// - `$iid_const`: The IID constant for the interface (unused but kept for consistency)
+                #[macro_export]
+                macro_rules! #forwarders_macro_name {
+                    ($struct_name:ident, $struct_type:ty, $interface_name:ident, $vtable_field:ident, $iid_const:ident) => {
+                        $crate::paste! {
+                            #(#forwarder_wrappers)*
+                        }
+                    };
+                }
+            },
+            quote! {
+                /// Auto-generated base vtable initializer macro for #trait_name.
+                ///
+                /// Returns an expression that creates `#vtable_name { ... }` with the wrapper function pointers.
+                #[macro_export]
+                macro_rules! #base_vtable_macro_name {
+                    ($struct_name:ident, $interface_name:ident) => {
+                        $crate::paste! {
+                            #vtable_name {
+                                #(#vtable_entries),*
+                            }
+                        }
+                    };
+                }
+            },
+        )
+    };
+
+    let expanded = quote! {
+        #iid_definition
+
+        #vtable_struct
 
         /// Base struct representing the interface pointer
         #[repr(C)]
@@ -579,19 +1068,7 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
         }
 
         impl #trait_name {
-            /// Get the interface ID pointer for this interface type (const-compatible)
-            #[inline]
-            #[must_use]
-            pub const fn interface_id_ptr() -> *const u8 {
-                &#iid_static_name as *const u8
-            }
-
-            /// Get the interface ID for this interface type as usize
-            #[inline]
-            #[must_use]
-            pub fn interface_id() -> usize {
-                Self::interface_id_ptr() as usize
-            }
+            #iid_methods
 
             /// Get the vtable
             #[inline]
@@ -600,21 +1077,14 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
                 unsafe { &*self.vtable }
             }
 
-            /// Wrap a raw C++ pointer for calling methods.
+            /// Wrap a raw pointer for calling methods.
             ///
             /// # Safety
             ///
-            /// - `ptr` must point to a valid C++ object with a compatible vtable layout
-            /// - The returned reference must not outlive the underlying C++ object
-            /// - The caller is responsible for ensuring the lifetime `'a` is valid;
-            ///   the C++ object must remain alive and unmoved for the duration of `'a`
+            /// - `ptr` must point to a valid object with a compatible vtable layout
+            /// - The returned reference must not outlive the underlying object
+            /// - The caller is responsible for ensuring the lifetime `'a` is valid
             /// - No mutable references to the same object may exist concurrently
-            ///
-            /// # Implementation Notes
-            ///
-            /// Uses `read_volatile` and `compiler_fence` to prevent the compiler from
-            /// optimizing away the pointer indirection, which is necessary when the
-            /// pointer comes from C++ code that the Rust compiler cannot reason about.
             #[inline]
             pub unsafe fn from_ptr<'a>(ptr: *mut std::ffi::c_void) -> &'a Self {
                 std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
@@ -622,22 +1092,14 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
                 &*(ptr as *const Self)
             }
 
-            /// Wrap a raw C++ pointer for calling methods (mutable).
+            /// Wrap a raw pointer for calling methods (mutable).
             ///
             /// # Safety
             ///
-            /// - `ptr` must point to a valid C++ object with a compatible vtable layout
-            /// - The returned reference must not outlive the underlying C++ object
-            /// - The caller is responsible for ensuring the lifetime `'a` is valid;
-            ///   the C++ object must remain alive and unmoved for the duration of `'a`
-            /// - No other references (mutable or immutable) to the same object may
-            ///   exist concurrently
-            ///
-            /// # Implementation Notes
-            ///
-            /// Uses `read_volatile` and `compiler_fence` to prevent the compiler from
-            /// optimizing away the pointer indirection, which is necessary when the
-            /// pointer comes from C++ code that the Rust compiler cannot reason about.
+            /// - `ptr` must point to a valid object with a compatible vtable layout
+            /// - The returned reference must not outlive the underlying object
+            /// - The caller is responsible for ensuring the lifetime `'a` is valid
+            /// - No other references to the same object may exist concurrently
             #[inline]
             pub unsafe fn from_ptr_mut<'a>(ptr: *mut std::ffi::c_void) -> &'a mut Self {
                 std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
@@ -645,8 +1107,18 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
                 &mut *(ptr as *mut Self)
             }
 
+            #iunknown_wrappers
+
             #(#wrapper_methods)*
         }
+
+        impl #krate::VTableLayout for #trait_name {
+            const SLOT_COUNT: usize = #slot_count_expr;
+            type VTable = #vtable_name;
+        }
+
+        #forwarders_macro
+        #base_vtable_macro
     };
 
     Ok(expanded)
@@ -661,6 +1133,10 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
 /// Supports `#[slot(N)]` attribute to specify explicit vtable slot indices.
 /// Gaps are filled with dummy entries that panic if called.
 ///
+/// # Options
+/// - `stdcall` - Use stdcall calling convention on x86 (default: thiscall)
+/// - `extends(IUnknown)` - Inherit IUnknown methods at slots 0-2
+///
 /// # Example
 /// ```ignore
 /// #[cppvtable]
@@ -670,18 +1146,219 @@ fn cppvtable_internal(attr: TokenStream, input: ItemTrait) -> Result<TokenStream
 ///     fn jump(&self);            // slot 5 (slots 1-4 filled with dummies)
 ///     fn legs(&self) -> i32;     // slot 6
 /// }
+///
+/// // COM-style with stdcall and IUnknown base
+/// #[cppvtable(stdcall, extends(IUnknown))]
+/// pub trait IComStyle {
+///     fn method(&self) -> i32;   // slot 3 (after IUnknown)
+/// }
 /// ```
 #[proc_macro_attribute]
 pub fn cppvtable(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemTrait);
-    match cppvtable_internal(attr, input) {
+
+    // Parse configuration from attributes
+    let config = match parse_cppvtable_config(attr) {
+        Ok(config) => config,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    match cppvtable_internal(config, input) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
     }
 }
 
+/// Parse cppvtable attribute options into a VTableConfig
+fn parse_cppvtable_config(attr: TokenStream) -> Result<VTableConfig, syn::Error> {
+    let mut config = VTableConfig::default();
+
+    if attr.is_empty() {
+        return Ok(config);
+    }
+
+    // Parse the attribute as a comma-separated list
+    let attr2: TokenStream2 = attr.into();
+    let tokens: Vec<_> = attr2.into_iter().collect();
+
+    let mut i = 0;
+    while i < tokens.len() {
+        match &tokens[i] {
+            proc_macro2::TokenTree::Ident(ident) => {
+                let name = ident.to_string();
+                match name.as_str() {
+                    "stdcall" => {
+                        config.calling_convention = CallingConvention::Stdcall;
+                        i += 1;
+                    }
+                    "thiscall" => {
+                        config.calling_convention = CallingConvention::Thiscall;
+                        i += 1;
+                    }
+                    "extends" => {
+                        // Expect: extends(BaseInterface)
+                        i += 1;
+                        if i >= tokens.len() {
+                            return Err(syn::Error::new(
+                                ident.span(),
+                                "expected '(' after 'extends'",
+                            ));
+                        }
+                        if let proc_macro2::TokenTree::Group(group) = &tokens[i] {
+                            // Parse the base interface identifier
+                            let base_ident: syn::Ident =
+                                syn::parse2(group.stream()).map_err(|_| {
+                                    syn::Error::new(
+                                        group.span(),
+                                        "expected an identifier inside 'extends(...)'",
+                                    )
+                                })?;
+                            config.base_interface = Some(base_ident);
+                            i += 1;
+                        } else {
+                            return Err(syn::Error::new(
+                                ident.span(),
+                                "expected '(...)' after 'extends'",
+                            ));
+                        }
+                    }
+                    "slots" => {
+                        // Expect: slots(method = N, ...)
+                        i += 1;
+                        if i >= tokens.len() {
+                            return Err(syn::Error::new(
+                                ident.span(),
+                                "expected '(' after 'slots'",
+                            ));
+                        }
+                        if let proc_macro2::TokenTree::Group(group) = &tokens[i] {
+                            config.slot_overrides =
+                                parse_slot_overrides_from_stream(group.stream());
+                            i += 1;
+                        } else {
+                            return Err(syn::Error::new(
+                                ident.span(),
+                                "expected '(...)' after 'slots'",
+                            ));
+                        }
+                    }
+                    "no_iid" => {
+                        // Skip IID generation - user defines their own IID
+                        config.iid = InterfaceId::None;
+                        i += 1;
+                    }
+                    "internal" => {
+                        // Use crate:: instead of cppvtable:: for paths
+                        // This is used when defining interfaces inside the cppvtable crate itself
+                        config.internal = true;
+                        i += 1;
+                    }
+                    "no_forwarders" => {
+                        // Skip generating forwarder macros
+                        // Use when forwarders need to be manually defined (e.g., IUnknown with COM types)
+                        config.no_forwarders = true;
+                        i += 1;
+                    }
+                    _ => {
+                        return Err(syn::Error::new(
+                            ident.span(),
+                            format!(
+                                "unknown option '{}', expected 'stdcall', 'thiscall', 'extends(...)', 'slots(...)', 'no_iid', 'internal', or 'no_forwarders'",
+                                name
+                            ),
+                        ));
+                    }
+                }
+            }
+            proc_macro2::TokenTree::Punct(punct) if punct.as_char() == ',' => {
+                i += 1; // Skip commas
+            }
+            other => {
+                return Err(syn::Error::new(
+                    other.span(),
+                    "unexpected token in cppvtable options",
+                ));
+            }
+        }
+    }
+
+    Ok(config)
+}
+
+/// Parse slot overrides from a token stream: method = N, ...
+fn parse_slot_overrides_from_stream(
+    stream: TokenStream2,
+) -> std::collections::HashMap<String, usize> {
+    let mut result = std::collections::HashMap::new();
+    let tokens: Vec<_> = stream.into_iter().collect();
+
+    /// Extract a literal value from a TokenTree, handling nested Groups
+    fn extract_literal(tt: &proc_macro2::TokenTree) -> Option<String> {
+        match tt {
+            proc_macro2::TokenTree::Literal(lit) => Some(lit.to_string()),
+            proc_macro2::TokenTree::Group(g) => {
+                // Handle case where macro expansion wraps literal in a None-delimited group
+                let inner: Vec<_> = g.stream().into_iter().collect();
+                if inner.len() == 1 {
+                    extract_literal(&inner[0])
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    let mut i = 0;
+    // Need at least 3 tokens: name = value
+    while i + 3 <= tokens.len() {
+        // Check for Ident = Value pattern
+        if let proc_macro2::TokenTree::Ident(name) = &tokens[i]
+            && let proc_macro2::TokenTree::Punct(eq) = &tokens[i + 1]
+            && eq.as_char() == '='
+        {
+            // Try to extract the value (may be Literal or Group containing Literal)
+            if let Some(lit_str) = extract_literal(&tokens[i + 2])
+                && let Ok(slot) = lit_str.parse::<usize>()
+            {
+                result.insert(name.to_string(), slot);
+            }
+            i += 3;
+            // Skip comma if present
+            if i < tokens.len()
+                && let proc_macro2::TokenTree::Punct(p) = &tokens[i]
+                && p.as_char() == ','
+            {
+                i += 1;
+            }
+            continue;
+        }
+        i += 1;
+    }
+
+    result
+}
+
 /// Internal implementation of cppvtable_impl
 fn cppvtable_impl_impl(interface_name: Ident, input: ItemImpl) -> Result<TokenStream2, syn::Error> {
+    // Use default config for regular C++ vtables
+    let config = ImplConfig {
+        calling_convention: CallingConvention::Thiscall,
+        base_interface: None,
+        first_slot: 0,
+        generate_rtti: true,
+        iid_const: None,
+        internal: false,
+    };
+    cppvtable_impl_internal(interface_name, input, config)
+}
+
+/// Core implementation shared by cppvtable_impl and com_implement
+fn cppvtable_impl_internal(
+    interface_name: Ident,
+    input: ItemImpl,
+    config: ImplConfig,
+) -> Result<TokenStream2, syn::Error> {
     // Validate impl block for C++ vtable compatibility
     validate_impl(&input)?;
 
@@ -693,6 +1370,12 @@ fn cppvtable_impl_impl(interface_name: Ident, input: ItemImpl) -> Result<TokenSt
         Type::Path(type_path) => type_path.path.segments.last().unwrap().ident.clone(),
         _ => return Err(syn::Error::new(struct_type.span(), "Expected a type path")),
     };
+
+    // Derive vtable field name from interface name
+    let vtable_field = interface_to_field_name(&interface_name);
+
+    // x86 calling convention
+    let x86_cc = config.x86_calling_conv();
 
     // Collect methods with their slot indices
     struct ImplMethodInfo {
@@ -706,7 +1389,7 @@ fn cppvtable_impl_impl(interface_name: Ident, input: ItemImpl) -> Result<TokenSt
     }
 
     let mut methods: Vec<ImplMethodInfo> = Vec::new();
-    let mut next_slot = 0usize;
+    let mut next_slot = config.first_slot;
 
     for item in &input.items {
         if let ImplItem::Fn(method) = item {
@@ -769,17 +1452,47 @@ fn cppvtable_impl_impl(interface_name: Ident, input: ItemImpl) -> Result<TokenSt
     // Sort by slot index
     methods.sort_by_key(|m| m.slot);
 
-    // Derive vtable field name from interface name for this-adjustment
-    let vtable_field = interface_to_field_name(&interface_name);
-
     // Generate wrapper functions and vtable entries, filling gaps
     let mut wrapper_fns = Vec::new();
     let mut vtable_entries = Vec::new();
     let mut original_methods = Vec::new();
-    let mut current_slot = 0usize;
+    let mut current_slot = config.first_slot;
+
+    // Generate base interface forwarders, vtable entry, and methods if configured
+    // Uses convention: base interface `IFoo` provides macros `ifoo_forwarders!`, `ifoo_base_vtable!`, `ifoo_methods!`
+    let krate = crate_path(config.internal);
+    let (base_forwarders, base_vtable_entry, base_methods) = if let Some(base) =
+        &config.base_interface
+    {
+        let base_lower = base.to_string().to_lowercase();
+        let forwarders_macro = format_ident!("{}_forwarders", base_lower);
+        let base_vtable_macro = format_ident!("{}_base_vtable", base_lower);
+        let methods_macro = format_ident!("{}_methods", base_lower);
+
+        let iid_const =
+            config.iid_const.as_ref().cloned().unwrap_or_else(|| {
+                format_ident!("IID_{}", interface_name.to_string().to_uppercase())
+            });
+
+        let forwarders = quote! {
+            #krate::#forwarders_macro!(#struct_name, #struct_type, #interface_name, #vtable_field, #iid_const);
+        };
+
+        let vtable_entry = quote! {
+            base: #krate::#base_vtable_macro!(#struct_name, #interface_name)
+        };
+
+        let methods = quote! {
+            #krate::#methods_macro!(#struct_type, #vtable_field, #iid_const);
+        };
+
+        (Some(forwarders), Some(vtable_entry), Some(methods))
+    } else {
+        (None, None, None)
+    };
 
     for method in &methods {
-        // Fill gaps with dummy panic stubs
+        // Fill gaps with dummy panic stubs (only for slots after first_slot)
         while current_slot < method.slot {
             let dummy_name = format_ident!("__reserved_slot_{}", current_slot);
             let dummy_wrapper =
@@ -788,7 +1501,7 @@ fn cppvtable_impl_impl(interface_name: Ident, input: ItemImpl) -> Result<TokenSt
             wrapper_fns.push(quote! {
                 #[allow(non_snake_case)]
                 #[cfg(target_arch = "x86")]
-                unsafe extern "thiscall" fn #dummy_wrapper(_this: *mut std::ffi::c_void) {
+                unsafe extern #x86_cc fn #dummy_wrapper(_this: *mut std::ffi::c_void) {
                     panic!("Called reserved vtable slot {}", #current_slot);
                 }
 
@@ -827,11 +1540,11 @@ fn cppvtable_impl_impl(interface_name: Ident, input: ItemImpl) -> Result<TokenSt
         };
 
         // Generate wrapper function
-        // x86: thiscall (this in ECX), x64: C calling convention
+        // x86: thiscall/stdcall depending on config, x64: C calling convention
         wrapper_fns.push(quote! {
             #[allow(non_snake_case)]
             #[cfg(target_arch = "x86")]
-            unsafe extern "thiscall" fn #wrapper_name(
+            unsafe extern #x86_cc fn #wrapper_name(
                 this: *mut std::ffi::c_void
                 #(, #param_names: #param_types)*
             ) #output {
@@ -879,38 +1592,76 @@ fn cppvtable_impl_impl(interface_name: Ident, input: ItemImpl) -> Result<TokenSt
     // Generate const name matching field naming convention: vtable_i_foo -> VTABLE_I_FOO
     let vtable_const_name = format_ident!("{}", vtable_field.to_string().to_uppercase());
 
-    // Generate RTTI InterfaceInfo const name: IFoo -> INTERFACE_INFO_I_FOO
-    let interface_info_const_name = format_ident!(
-        "INTERFACE_INFO_{}",
-        vtable_field
-            .to_string()
-            .trim_start_matches("vtable_")
-            .to_uppercase()
-    );
+    // Build vtable entries with optional base vtable entry (e.g., base: IUnknownVTable { ... })
+    let vtable_body = if let Some(base_entry) = &base_vtable_entry {
+        quote! {
+            #base_entry,
+            #(#vtable_entries),*
+        }
+    } else {
+        quote! {
+            #(#vtable_entries),*
+        }
+    };
+
+    // Generate RTTI if configured
+    let rtti_const = if config.generate_rtti {
+        let interface_info_const_name = format_ident!(
+            "INTERFACE_INFO_{}",
+            vtable_field
+                .to_string()
+                .trim_start_matches("vtable_")
+                .to_uppercase()
+        );
+        quote! {
+            /// RTTI: Interface info for this interface implementation.
+            /// Contains interface ID and byte offset from struct start.
+            pub const #interface_info_const_name: #krate::InterfaceInfo = #krate::InterfaceInfo {
+                interface_id: #interface_name::interface_id_ptr(),
+                offset: ::std::mem::offset_of!(Self, #vtable_field) as isize,
+            };
+        }
+    } else {
+        quote! {}
+    };
+
+    // Generate IID const for COM interfaces
+    let iid_const = if let Some(iid_name) = &config.iid_const {
+        quote! {
+            /// COM IID for this interface
+            pub const IID: &'static #krate::GUID = &#iid_name;
+        }
+    } else {
+        quote! {}
+    };
+
+    // Extra methods from base interface (e.g., query_interface/add_ref/release for IUnknown)
+    let extra_methods = base_methods.unwrap_or_default();
 
     let expanded = quote! {
+        // Base interface forwarders (e.g., IUnknown wrapper functions)
+        #base_forwarders
+
         // The wrapper functions (private)
         #(#wrapper_fns)*
 
         // Static vtable instance
         static #vtable_static_name: #vtable_name = #vtable_name {
-            #(#vtable_entries),*
+            #vtable_body
         };
 
-        // Original impl with methods + vtable const accessor + RTTI
+        // Original impl with methods + vtable const accessor
         impl #struct_type {
             /// Pointer to the vtable for this interface implementation.
             /// Use this when constructing the struct.
             pub const #vtable_const_name: *const #vtable_name = &#vtable_static_name;
 
-            /// RTTI: Interface info for this interface implementation.
-            /// Contains interface ID and byte offset from struct start.
-            pub const #interface_info_const_name: cppvtable::InterfaceInfo = cppvtable::InterfaceInfo {
-                interface_id: #interface_name::interface_id_ptr(),
-                offset: ::std::mem::offset_of!(Self, #vtable_field) as isize,
-            };
+            #iid_const
+            #rtti_const
 
             #(#original_methods)*
+
+            #extra_methods
         }
     };
 
@@ -942,6 +1693,186 @@ pub fn cppvtable_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let interface_name = parse_macro_input!(attr as Ident);
     let input = parse_macro_input!(item as ItemImpl);
     match cppvtable_impl_impl(interface_name, input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+// =============================================================================
+// COM Interface Support
+// =============================================================================
+
+/// Parse a GUID string in format "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+/// Returns (data1, data2, data3, data4) tuple
+fn parse_guid_string(s: &str) -> Result<(u32, u16, u16, [u8; 8]), String> {
+    let s = s.trim();
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 5 {
+        return Err(format!(
+            "Invalid GUID format: expected 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', got '{}'",
+            s
+        ));
+    }
+
+    let data1 = u32::from_str_radix(parts[0], 16)
+        .map_err(|_| format!("Invalid GUID data1: '{}'", parts[0]))?;
+    let data2 = u16::from_str_radix(parts[1], 16)
+        .map_err(|_| format!("Invalid GUID data2: '{}'", parts[1]))?;
+    let data3 = u16::from_str_radix(parts[2], 16)
+        .map_err(|_| format!("Invalid GUID data3: '{}'", parts[2]))?;
+
+    // parts[3] is 4 hex chars (2 bytes), parts[4] is 12 hex chars (6 bytes)
+    if parts[3].len() != 4 {
+        return Err(format!(
+            "Invalid GUID data4 first part: expected 4 hex chars, got '{}'",
+            parts[3]
+        ));
+    }
+    if parts[4].len() != 12 {
+        return Err(format!(
+            "Invalid GUID data4 second part: expected 12 hex chars, got '{}'",
+            parts[4]
+        ));
+    }
+
+    let mut data4 = [0u8; 8];
+    data4[0] = u8::from_str_radix(&parts[3][0..2], 16)
+        .map_err(|_| format!("Invalid GUID data4[0]: '{}'", &parts[3][0..2]))?;
+    data4[1] = u8::from_str_radix(&parts[3][2..4], 16)
+        .map_err(|_| format!("Invalid GUID data4[1]: '{}'", &parts[3][2..4]))?;
+    for i in 0..6 {
+        data4[2 + i] = u8::from_str_radix(&parts[4][i * 2..i * 2 + 2], 16).map_err(|_| {
+            format!(
+                "Invalid GUID data4[{}]: '{}'",
+                2 + i,
+                &parts[4][i * 2..i * 2 + 2]
+            )
+        })?;
+    }
+
+    Ok((data1, data2, data3, data4))
+}
+
+/// Define a COM interface.
+///
+/// This generates:
+/// - A vtable struct `{Name}VTable` with IUnknown methods (slots 0-2) + your methods
+/// - An interface wrapper struct `{Name}` with method wrappers
+/// - An IID constant `IID_{NAME}` parsed from the GUID string
+///
+/// Uses `stdcall` calling convention on x86 (not `thiscall` like C++ vtables).
+///
+/// # Example
+/// ```ignore
+/// #[com_interface("12345678-1234-1234-1234-123456789abc")]
+/// pub trait IMyInterface {
+///     fn do_something(&self, x: i32) -> HRESULT;
+///     #[slot(5)]
+///     fn do_other(&self) -> HRESULT;  // slot 5 (slots 3-4 filled with dummies)
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn com_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Parse the GUID string from the attribute
+    let guid_str: syn::LitStr = match syn::parse(attr) {
+        Ok(s) => s,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    // Parse GUID
+    let (data1, data2, data3, data4) = match parse_guid_string(&guid_str.value()) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            return syn::Error::new(guid_str.span(), e)
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    // Create COM config: stdcall + extends(IUnknown) + GUID IID
+    let config = VTableConfig {
+        calling_convention: CallingConvention::Stdcall,
+        base_interface: Some(syn::Ident::new("IUnknown", proc_macro2::Span::call_site())),
+        iid: InterfaceId::Guid {
+            data1,
+            data2,
+            data3,
+            data4,
+        },
+        slot_overrides: std::collections::HashMap::new(),
+        internal: false,
+        no_forwarders: false,
+    };
+
+    let input = parse_macro_input!(item as ItemTrait);
+    match cppvtable_internal(config, input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Internal implementation of com_implement
+fn com_implement_internal(
+    interface_name: Ident,
+    input: ItemImpl,
+) -> Result<TokenStream2, syn::Error> {
+    // COM uses stdcall, inherits from IUnknown (3 slots), no RTTI
+    let iid_const = format_ident!("IID_{}", interface_name.to_string().to_uppercase());
+
+    let config = ImplConfig {
+        calling_convention: CallingConvention::Stdcall,
+        base_interface: Some(format_ident!("IUnknown")),
+        first_slot: 3, // IUnknown has QueryInterface, AddRef, Release
+        generate_rtti: false,
+        iid_const: Some(iid_const),
+        internal: false,
+    };
+
+    cppvtable_impl_internal(interface_name, input, config)
+}
+
+/// Implement a COM interface for a struct.
+///
+/// This generates:
+/// - Static vtable instance with IUnknown methods (QueryInterface, AddRef, Release)
+/// - Wrapper functions that cast `this` and call your methods
+/// - A vtable accessor constant (`VTABLE_I_INTERFACE_NAME`)
+/// - IUnknown methods on the struct (`query_interface`, `add_ref`, `release`)
+///
+/// # Requirements
+///
+/// Your struct must have:
+/// - A `ref_count: ComRefCount` field for reference counting
+/// - A vtable pointer field named `vtable_i_{interface_name}` (auto-derived from interface name)
+///
+/// # Example
+/// ```ignore
+/// #[repr(C)]
+/// struct MyObject {
+///     vtable_i_my_interface: *const IMyInterfaceVTable,
+///     ref_count: ComRefCount,
+///     // ... other fields
+/// }
+///
+/// impl MyObject {
+///     pub fn new() -> Self {
+///         Self {
+///             vtable_i_my_interface: Self::VTABLE_I_MY_INTERFACE,
+///             ref_count: ComRefCount::new(),
+///         }
+///     }
+/// }
+///
+/// #[com_implement(IMyInterface)]
+/// impl MyObject {
+///     fn do_something(&self, x: i32) -> HRESULT { S_OK }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn com_implement(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let interface_name = parse_macro_input!(attr as Ident);
+    let input = parse_macro_input!(item as ItemImpl);
+    match com_implement_internal(interface_name, input) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
     }

--- a/crates/cppvtable/Cargo.toml
+++ b/crates/cppvtable/Cargo.toml
@@ -6,6 +6,11 @@ description = "C++ vtable interop for Rust (MSVC ABI compatible)"
 license = "MIT"
 repository = "https://github.com/coconutbird/cppvtable"
 
+[features]
+default = []
+windows-compat = ["dep:windows-core"]
+
 [dependencies]
 paste = "1.0"
 cppvtable-macro = { path = "../cppvtable-macro" }
+windows-core = { version = "0.62", optional = true }

--- a/crates/cppvtable/src/com.rs
+++ b/crates/cppvtable/src/com.rs
@@ -262,13 +262,16 @@ pub const IID_IUNKNOWN: GUID = GUID::new(
 ///
 /// Every COM interface vtable starts with these three methods at slots 0, 1, 2.
 /// This generates:
-/// - `IUnknownVTable` struct with function pointers
+/// - `IUnknownVTable<T>` struct with function pointers (generic for typed this pointer)
 /// - `IUnknown` wrapper struct with safe methods
 /// - `VTableLayout` impl
 /// - `iunknown_forwarders!` macro for derived interfaces
 /// - `iunknown_base_vtable!` macro for vtable initialization
+///
+/// The generic parameter `T` represents the concrete type implementing the interface,
+/// allowing type-safe function pointers with `*mut T` instead of `*mut c_void`.
 #[crate::proc::cppvtable(stdcall, no_iid, internal)]
-pub trait IUnknown {
+pub trait IUnknown<T> {
     /// Query for another interface by GUID.
     fn query_interface(&self, riid: *const GUID, ppv: *mut *mut c_void) -> HRESULT;
 

--- a/crates/cppvtable/src/com.rs
+++ b/crates/cppvtable/src/com.rs
@@ -1,0 +1,277 @@
+//! COM (Component Object Model) support types
+//!
+//! This module provides core COM types for use with `#[com_interface]` and `#[com_implement]`.
+//!
+//! ## Key Types
+//! - [`GUID`] - 128-bit globally unique identifier for interfaces
+//! - [`HRESULT`] - COM return type for error handling
+//! - [`IUnknownVTable`] - Base vtable for all COM interfaces
+//!
+//! ## Example
+//! ```ignore
+//! use cppvtable::com::*;
+//! use cppvtable::proc::{com_interface, com_implement};
+//!
+//! #[com_interface("12345678-1234-1234-1234-123456789abc")]
+//! pub trait IMyInterface {
+//!     fn do_something(&self, x: i32) -> HRESULT;
+//! }
+//! ```
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+// =============================================================================
+// GUID - Globally Unique Identifier
+// =============================================================================
+
+/// 128-bit globally unique identifier (GUID/UUID/IID).
+///
+/// Used for interface identification in COM. Format: `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}`
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GUID {
+    pub data1: u32,
+    pub data2: u16,
+    pub data3: u16,
+    pub data4: [u8; 8],
+}
+
+impl GUID {
+    /// Create a new GUID from components
+    #[must_use]
+    pub const fn new(data1: u32, data2: u16, data3: u16, data4: [u8; 8]) -> Self {
+        Self {
+            data1,
+            data2,
+            data3,
+            data4,
+        }
+    }
+
+    /// The nil/zero GUID
+    pub const ZERO: GUID = GUID::new(0, 0, 0, [0; 8]);
+}
+
+impl std::fmt::Debug for GUID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}}}",
+            self.data1,
+            self.data2,
+            self.data3,
+            self.data4[0],
+            self.data4[1],
+            self.data4[2],
+            self.data4[3],
+            self.data4[4],
+            self.data4[5],
+            self.data4[6],
+            self.data4[7]
+        )
+    }
+}
+
+impl std::fmt::Display for GUID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:08x}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            self.data1,
+            self.data2,
+            self.data3,
+            self.data4[0],
+            self.data4[1],
+            self.data4[2],
+            self.data4[3],
+            self.data4[4],
+            self.data4[5],
+            self.data4[6],
+            self.data4[7]
+        )
+    }
+}
+
+// =============================================================================
+// HRESULT - COM error codes
+// =============================================================================
+
+/// COM result type. 0 (S_OK) indicates success, negative values indicate errors.
+pub type HRESULT = i32;
+
+/// Success
+pub const S_OK: HRESULT = 0;
+/// Success, but returned false
+pub const S_FALSE: HRESULT = 1;
+/// No such interface supported
+pub const E_NOINTERFACE: HRESULT = 0x8000_4002_u32 as i32;
+/// Invalid pointer
+pub const E_POINTER: HRESULT = 0x8000_4003_u32 as i32;
+/// Unspecified failure
+pub const E_FAIL: HRESULT = 0x8000_4005_u32 as i32;
+/// Out of memory
+pub const E_OUTOFMEMORY: HRESULT = 0x8007_000E_u32 as i32;
+/// Invalid argument
+pub const E_INVALIDARG: HRESULT = 0x8007_0057_u32 as i32;
+/// Not implemented
+pub const E_NOTIMPL: HRESULT = 0x8000_4001_u32 as i32;
+
+/// Check if an HRESULT indicates success (non-negative)
+#[inline]
+#[must_use]
+pub const fn succeeded(hr: HRESULT) -> bool {
+    hr >= 0
+}
+
+/// Check if an HRESULT indicates failure (negative)
+#[inline]
+#[must_use]
+pub const fn failed(hr: HRESULT) -> bool {
+    hr < 0
+}
+
+// =============================================================================
+// IUnknown - Base COM interface
+// =============================================================================
+
+/// IUnknown interface ID
+pub const IID_IUNKNOWN: GUID = GUID::new(
+    0x00000000,
+    0x0000,
+    0x0000,
+    [0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46],
+);
+
+/// IUnknown - base of all COM interfaces.
+///
+/// Every COM interface vtable starts with these three methods at slots 0, 1, 2.
+/// This generates:
+/// - `IUnknownVTable` struct with function pointers
+/// - `IUnknown` wrapper struct with safe methods
+/// - `VTableLayout` impl
+/// - `iunknown_forwarders!` macro for derived interfaces
+/// - `iunknown_base_vtable!` macro for vtable initialization
+#[crate::proc::cppvtable(stdcall, no_iid, internal)]
+pub trait IUnknown {
+    /// Query for another interface by GUID.
+    fn query_interface(&self, riid: *const GUID, ppv: *mut *mut c_void) -> HRESULT;
+
+    /// Increment reference count. Returns new count.
+    fn add_ref(&self) -> u32;
+
+    /// Decrement reference count. Returns new count.
+    fn release(&mut self) -> u32;
+}
+
+// =============================================================================
+// ComRefCount - Atomic reference counter for COM objects
+// =============================================================================
+
+/// Atomic reference counter for COM objects.
+///
+/// Embed this in your COM object struct for automatic reference counting.
+/// Use with `#[com_implement]` for auto-generated AddRef/Release.
+#[repr(transparent)]
+pub struct ComRefCount(AtomicU32);
+
+impl ComRefCount {
+    /// Create a new reference counter with count = 1
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(AtomicU32::new(1))
+    }
+
+    /// Increment the reference count. Returns the new count.
+    #[inline]
+    pub fn add_ref(&self) -> u32 {
+        self.0.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Decrement the reference count. Returns the new count.
+    ///
+    /// When count reaches 0, the caller should destroy the object.
+    #[inline]
+    pub fn release(&self) -> u32 {
+        self.0.fetch_sub(1, Ordering::Release) - 1
+    }
+
+    /// Get the current reference count.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u32 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for ComRefCount {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Helper trait for COM interface identification
+// =============================================================================
+
+/// Trait for types that have a COM interface ID (IID).
+///
+/// Automatically implemented by `#[com_interface]`.
+pub trait ComInterface {
+    /// The interface ID (IID) for this interface.
+    const IID: GUID;
+}
+
+// =============================================================================
+// IUnknown method implementations macro
+// =============================================================================
+
+/// Generates the IUnknown method implementations for a COM object.
+///
+/// Expects the struct to have a `ref_count: ComRefCount` field.
+#[macro_export]
+macro_rules! iunknown_methods {
+    ($struct_type:ty, $vtable_field:ident, $iid_const:ident) => {
+        /// Query for another interface by GUID.
+        ///
+        /// Returns `S_OK` if the interface is supported, `E_NOINTERFACE` otherwise.
+        ///
+        /// # Safety
+        /// - `riid` must point to a valid GUID
+        /// - `ppv` must point to a valid, writable pointer location
+        pub unsafe fn query_interface(
+            &self,
+            riid: *const $crate::GUID,
+            ppv: *mut *mut ::std::ffi::c_void,
+        ) -> $crate::HRESULT {
+            unsafe {
+                if ppv.is_null() {
+                    return $crate::E_POINTER;
+                }
+
+                let riid_ref = &*riid;
+
+                // Check if requested IID matches this interface or IUnknown
+                if *riid_ref == $iid_const || *riid_ref == $crate::IID_IUNKNOWN {
+                    let ptr = &self.$vtable_field as *const _ as *mut ::std::ffi::c_void;
+                    *ppv = ptr;
+                    self.add_ref();
+                    return $crate::S_OK;
+                }
+
+                *ppv = ::std::ptr::null_mut();
+                $crate::E_NOINTERFACE
+            }
+        }
+
+        /// Increment the reference count.
+        pub fn add_ref(&self) -> u32 {
+            self.ref_count.add_ref()
+        }
+
+        /// Decrement the reference count.
+        pub fn release(&mut self) -> u32 {
+            self.ref_count.release()
+        }
+    };
+}

--- a/crates/cppvtable/src/lib.rs
+++ b/crates/cppvtable/src/lib.rs
@@ -63,11 +63,44 @@
 //! | RTTI support | ✅ | ✅ |
 //! | Multiple inheritance | ✅ | ✅ |
 
+pub mod com;
 pub mod decl;
 pub mod rtti;
 
+// =============================================================================
+// VTableLayout - Trait for interface inheritance
+// =============================================================================
+
+/// Trait providing vtable layout information for interface inheritance.
+///
+/// This trait is automatically implemented by `#[cppvtable]` for each interface.
+/// It enables `extends(Base)` to inherit from another interface.
+///
+/// # Example
+/// ```ignore
+/// use cppvtable::proc::cppvtable;
+///
+/// #[cppvtable]
+/// pub trait IBase {
+///     fn base_method(&self);
+/// }
+///
+/// #[cppvtable(extends(IBase))]
+/// pub trait IDerived {
+///     fn derived_method(&self);  // Starts at slot 1
+/// }
+/// ```
+pub trait VTableLayout {
+    /// The number of vtable slots used by this interface (including inherited slots).
+    const SLOT_COUNT: usize;
+
+    /// The vtable struct type for this interface.
+    type VTable;
+}
+
 /// Proc-macro approach - re-exports from cppvtable-macro crate
 pub mod proc {
+    pub use cppvtable_macro::{com_implement, com_interface};
     pub use cppvtable_macro::{cppvtable, cppvtable_impl};
 }
 
@@ -84,3 +117,10 @@ pub use std::sync::atomic::{Ordering, compiler_fence};
 // Re-export RTTI types for macro-generated code
 #[doc(hidden)]
 pub use rtti::{InterfaceInfo, TypeInfo};
+
+// Re-export COM types for macro-generated code
+#[doc(hidden)]
+pub use com::{
+    ComRefCount, E_NOINTERFACE, E_POINTER, GUID, HRESULT, IID_IUNKNOWN, IUnknown, IUnknownVTable,
+    S_OK,
+};

--- a/crates/cppvtable/src/lib.rs
+++ b/crates/cppvtable/src/lib.rs
@@ -122,5 +122,5 @@ pub use rtti::{InterfaceInfo, TypeInfo};
 #[doc(hidden)]
 pub use com::{
     ComRefCount, E_NOINTERFACE, E_POINTER, GUID, HRESULT, IID_IUNKNOWN, IUnknown, IUnknownVTable,
-    S_OK,
+    S_OK, make_guid,
 };

--- a/crates/cppvtable/tests/com.rs
+++ b/crates/cppvtable/tests/com.rs
@@ -1,0 +1,216 @@
+//! Tests for COM interface support
+
+use cppvtable::com::{ComRefCount, IUnknownVTable, S_OK};
+use cppvtable::proc::{com_implement, com_interface};
+use cppvtable::{IUnknown, VTableLayout};
+use std::ffi::c_void;
+use std::ptr;
+
+// =============================================================================
+// Test: Basic COM interface definition
+// =============================================================================
+
+#[com_interface("12345678-1234-5678-9abc-def012345678")]
+pub trait ICalculator {
+    fn add(&self, a: i32, b: i32) -> i32;
+    fn multiply(&self, a: i32, b: i32) -> i32;
+}
+
+#[test]
+fn test_com_interface_iid() {
+    let iid = ICalculator::iid();
+    assert_eq!(iid.data1, 0x12345678);
+    assert_eq!(iid.data2, 0x1234);
+    assert_eq!(iid.data3, 0x5678);
+    assert_eq!(iid.data4, [0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78]);
+}
+
+#[test]
+fn test_com_interface_iid_const() {
+    // IID constant should also be available
+    assert_eq!(IID_ICALCULATOR.data1, 0x12345678);
+}
+
+#[test]
+fn test_com_vtable_has_iunknown_methods() {
+    // Verify vtable has IUnknown methods at expected positions
+    let vtable_size = std::mem::size_of::<ICalculatorVTable>();
+    // Should be: IUnknownVTable (3 ptrs) + 2 user methods = 5 function pointers worth
+    // On 64-bit: 5 * 8 = 40 bytes
+    // On 32-bit: 5 * 4 = 20 bytes
+    let ptr_size = std::mem::size_of::<*const c_void>();
+    assert_eq!(vtable_size, 5 * ptr_size);
+}
+
+// =============================================================================
+// Test: VTableLayout trait and inheritance
+// =============================================================================
+
+#[test]
+fn test_iunknown_vtable_layout() {
+    // IUnknown has 3 methods: QueryInterface, AddRef, Release
+    assert_eq!(<IUnknown as VTableLayout>::SLOT_COUNT, 3);
+
+    // VTable type should be IUnknownVTable (verify via size)
+    assert_eq!(
+        std::mem::size_of::<<IUnknown as VTableLayout>::VTable>(),
+        std::mem::size_of::<IUnknownVTable>()
+    );
+}
+
+#[test]
+fn test_derived_interface_vtable_layout() {
+    // ICalculator extends IUnknown (3) + 2 own methods = 5 total slots
+    assert_eq!(<ICalculator as VTableLayout>::SLOT_COUNT, 5);
+
+    // VTable type should be ICalculatorVTable (verify via size)
+    assert_eq!(
+        std::mem::size_of::<<ICalculator as VTableLayout>::VTable>(),
+        std::mem::size_of::<ICalculatorVTable>()
+    );
+}
+
+#[test]
+fn test_vtable_base_field_offset() {
+    // The `base` field (IUnknownVTable) should be at offset 0
+    let base_offset = std::mem::offset_of!(ICalculatorVTable, base);
+    assert_eq!(base_offset, 0);
+}
+
+#[test]
+fn test_vtable_embeds_iunknown() {
+    // ICalculatorVTable should embed IUnknownVTable as its first field
+    let iunknown_size = std::mem::size_of::<IUnknownVTable>();
+    let ptr_size = std::mem::size_of::<*const c_void>();
+
+    // IUnknownVTable should be 3 function pointers
+    assert_eq!(iunknown_size, 3 * ptr_size);
+
+    // ICalculatorVTable.base should be exactly IUnknownVTable sized
+    // (this verifies the embedded struct, not a pointer)
+    assert_eq!(
+        std::mem::size_of::<<IUnknown as VTableLayout>::VTable>(),
+        iunknown_size
+    );
+}
+
+// =============================================================================
+// Test: COM interface implementation
+// =============================================================================
+
+#[repr(C)]
+pub struct Calculator {
+    vtable_i_calculator: *const ICalculatorVTable,
+    ref_count: ComRefCount,
+    base_value: i32,
+}
+
+impl Calculator {
+    pub fn new(base: i32) -> Self {
+        Self {
+            vtable_i_calculator: Self::VTABLE_I_CALCULATOR,
+            ref_count: ComRefCount::new(),
+            base_value: base,
+        }
+    }
+}
+
+#[com_implement(ICalculator)]
+impl Calculator {
+    fn add(&self, a: i32, b: i32) -> i32 {
+        self.base_value + a + b
+    }
+
+    fn multiply(&self, a: i32, b: i32) -> i32 {
+        self.base_value * a * b
+    }
+}
+
+#[test]
+fn test_com_implement_basic() {
+    let calc = Calculator::new(10);
+
+    // Call methods directly
+    assert_eq!(calc.add(2, 3), 15); // 10 + 2 + 3
+    assert_eq!(calc.multiply(2, 3), 60); // 10 * 2 * 3
+}
+
+#[test]
+fn test_com_implement_vtable_calls() {
+    let mut calc = Calculator::new(10);
+
+    // Get interface pointer and call through vtable
+    unsafe {
+        let iface = ICalculator::from_ptr_mut(&mut calc as *mut _ as *mut c_void);
+        assert_eq!(iface.add(1, 2), 13); // 10 + 1 + 2
+        assert_eq!(iface.multiply(2, 2), 40); // 10 * 2 * 2
+    }
+}
+
+#[test]
+fn test_com_ref_counting() {
+    let mut calc = Calculator::new(10);
+
+    unsafe {
+        let iface = ICalculator::from_ptr_mut(&mut calc as *mut _ as *mut c_void);
+
+        // Initial ref count is 1
+        assert_eq!(calc.ref_count.count(), 1);
+
+        // AddRef increments
+        let count = iface.add_ref();
+        assert_eq!(count, 2);
+        assert_eq!(calc.ref_count.count(), 2);
+
+        // Release decrements
+        let count = iface.release();
+        assert_eq!(count, 1);
+        assert_eq!(calc.ref_count.count(), 1);
+    }
+}
+
+#[test]
+fn test_com_query_interface() {
+    let calc = Calculator::new(10);
+
+    unsafe {
+        let iface = ICalculator::from_ptr(&calc as *const _ as *mut c_void);
+
+        // Query for the same interface
+        let mut ppv: *mut c_void = ptr::null_mut();
+        let hr = iface.query_interface(ICalculator::iid(), &mut ppv);
+        assert_eq!(hr, S_OK);
+        assert!(!ppv.is_null());
+
+        // Queried pointer should work
+        let iface2 = ICalculator::from_ptr_mut(ppv);
+        assert_eq!(iface2.add(1, 1), 12);
+
+        // Release the extra reference from QueryInterface
+        iface2.release();
+    }
+}
+
+// =============================================================================
+// Test: Auto-generated forwarders for derived interfaces
+// =============================================================================
+
+// Define IScientificCalculator extending ICalculator
+// This tests that the auto-generated icalculator_forwarders! and icalculator_base_vtable! macros exist
+#[cppvtable::proc::cppvtable(stdcall, extends(ICalculator))]
+pub trait IScientificCalculator {
+    fn square(&self, x: i32) -> i32;
+}
+
+#[test]
+fn test_derived_interface_extends_calculator() {
+    // IScientificCalculator should have ICalculator's slot count + 1 own method
+    assert_eq!(<IScientificCalculator as VTableLayout>::SLOT_COUNT, 6);
+
+    // Vtable should be the right size: ICalculator (5 slots) + 1 own = 6 function pointers
+    let ptr_size = std::mem::size_of::<*const c_void>();
+    assert_eq!(
+        std::mem::size_of::<IScientificCalculatorVTable>(),
+        6 * ptr_size
+    );
+}


### PR DESCRIPTION
This PR adds support for generic COM interfaces with type-safe vtable function pointers.

## Changes

- Make `IUnknown` generic (`IUnknown<T>`) for type-safe function pointers
- Fix calling convention from `extern "C"` to `extern "system"` on x64
- Properly propagate generic type parameters to base vtables
- Add `windows-compat` feature for compatibility with the `windows` crate GUID/HRESULT types

This enables creating type-safe 7-Zip plugins where vtable function pointers use `*mut PluginHandler<T>` instead of `*mut c_void`.